### PR TITLE
Fix Invalid Namespace Hanging

### DIFF
--- a/socketIO_client/namespaces.py
+++ b/socketIO_client/namespaces.py
@@ -1,4 +1,5 @@
 from .logs import LoggingMixin
+from requests.exceptions import ConnectionError
 
 
 class EngineIONamespace(LoggingMixin):
@@ -118,7 +119,7 @@ class SocketIONamespace(EngineIONamespace):
 
     def on_error(self, data):
         if data == 'Invalid namespace':
-            raise ConnectionAbortedError
+            raise ConnectionError
         """Called after socket.io sends an error packet.
         You can override this method."""
 

--- a/socketIO_client/namespaces.py
+++ b/socketIO_client/namespaces.py
@@ -117,6 +117,8 @@ class SocketIONamespace(EngineIONamespace):
             socketIO.define(Namespace)"""
 
     def on_error(self, data):
+        if data == 'Invalid namespace':
+            raise ConnectionAbortedError
         """Called after socket.io sends an error packet.
         You can override this method."""
 


### PR DESCRIPTION
If you try and connect to an Invalid namespace you get an error back - but without any handler you end up just hanging (this issue was previously described in more detail here: invisibleroads#84)

I'm not sure whether this belongs in this SocketIO "namespace" or the parent EngineIO - welcome to adjust. Also welcome to adjust on the exception (whether Socket IO specific or another generic Python one)
