### PR TITLE
Correctly close underlining TCP connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ sdist
 .coverage
 node_modules
 htmlcov
+.idea

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ DESCRIPTION = '\n\n'.join(LOAD_TEXT(_) for _ in [
 ])
 setup(
     name='socketIO-client-2',
-    version='0.7.2',
+    version='0.7.3',
     description='A socket.io client library',
     long_description=DESCRIPTION,
     license='MIT',

--- a/socketIO_client/__init__.py
+++ b/socketIO_client/__init__.py
@@ -14,7 +14,7 @@ from .transports import (
 
 
 __all__ = 'SocketIO', 'SocketIONamespace'
-__version__ = '0.6.3'
+__version__ = '0.7.3'
 BaseNamespace = SocketIONamespace
 LoggingNamespace = LoggingSocketIONamespace
 
@@ -175,15 +175,19 @@ class EngineIO(LoggingMixin):
         self._wants_to_close = True
         try:
             self._heartbeat_thread.halt()
+            self._heartbeat_thread.join()
         except AttributeError:
             pass
-        if not self._opened:
+        if not hasattr(self, '_opened') or not self._opened:
+            self._http_session.close()
             return
         engineIO_packet_type = 1
         try:
             self._transport_instance.send_packet(engineIO_packet_type)
         except (TimeoutError, ConnectionError):
             pass
+        self._http_session.close()
+        self._transport_instance.close()
         self._opened = False
 
     def _ping(self, engineIO_packet_data=''):

--- a/socketIO_client/transports.py
+++ b/socketIO_client/transports.py
@@ -45,6 +45,9 @@ class AbstractTransport(object):
     def set_timeout(self, seconds=None):
         pass
 
+    def close(self):
+        pass
+
 
 class XHR_PollingTransport(AbstractTransport):
 
@@ -170,6 +173,9 @@ class WebsocketTransport(AbstractTransport):
 
     def set_timeout(self, seconds=None):
         self._connection.settimeout(seconds or self._timeout)
+
+    def close(self):
+        self._connection.close()
 
 
 def get_response(request, *args, **kw):


### PR DESCRIPTION
Currently, when the disconnect() is called, the SocketIO client does not close the underlying TCP connections for the HTTP or WebSocket sessions. Under heavy load, it is possible to hit the maximum TCP connections or file handle limits. This pull request correctly closes the underlying TCP connection for the HTTP and WebSocket sessions.

Based on this pull request: https://github.com/invisibleroads/socketIO-client/pull/126/files

I have also bumped the version number ready for release… :wink: