### PR TITLE
Log to a subdirectory so logging handlers can choose logging levels

### DIFF
--- a/socketIO_client/logs.py
+++ b/socketIO_client/logs.py
@@ -1,11 +1,15 @@
 import logging
 import time
+from .symmetries import NullHandler
+
+LOGGER = logging.getLogger('socketIO-client-2')
+LOGGER.addHandler(NullHandler())
 
 
 class LoggingMixin(object):
 
     def _log(self, level, msg, *attrs):
-        logging.log(level, '%s %s' % (self._log_name, msg), *attrs)
+        LOGGER.log(level, '%s %s' % (self._log_name, msg), *attrs)
 
     def _debug(self, msg, *attrs):
         self._log(logging.DEBUG, msg, *attrs)

--- a/socketIO_client/symmetries.py
+++ b/socketIO_client/symmetries.py
@@ -1,4 +1,12 @@
 import six
+
+try:
+    from logging import NullHandler
+except ImportError:  # Python 2.6
+    from logging import Handler
+    class NullHandler(Handler):
+        def emit(self, record):
+            pass
 try:
     from urllib import urlencode as format_query
 except ImportError:


### PR DESCRIPTION
https://github.com/invisibleroads/socketIO-client/pull/105 This is a port of this issue which allows handling the logging of the client by applications. Currently we're getting our data pushed out to stdout as a debug which is just a nightmare.